### PR TITLE
 Add support to test the websocket connection 

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -34,6 +34,7 @@ class Connection:
         command_character: str,
         administrators: List[str],
         domain: str,
+        unittesting: bool = False,
     ) -> None:
         self.url = url
         self.username = username
@@ -49,6 +50,7 @@ class Connection:
         self.command_character = command_character
         self.administrators = [utils.to_user_id(user) for user in administrators]
         self.domain = domain
+        self.unittesting = unittesting
         self.users: WeakValueDictionary[  # pylint: disable=unsubscriptable-object
             UserId, User
         ] = WeakValueDictionary()

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,6 +37,9 @@ implicit_reexport = False
 strict_equality = True
 
 
-# pytest decorators leave functions untyped after transformation
 [mypy-tests.*]
+# pytest decorators leave functions untyped after transformation
 disallow_any_decorated = False
+disallow_any_explicit = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,4 +5,5 @@ mypy
 pip-tools
 pylint
 pytest
+pytest-mock
 https://github.com/dropbox/sqlalchemy-stubs/archive/55470ceab8149db983411d5c094c9fe16343c58b.zip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,10 +110,14 @@ pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
     # via packaging
+pytest-mock==3.3.1 \
+    --hash=sha256:024e405ad382646318c4281948aadf6fe1135632bea9cc67366ea0c4098ef5f2 \
+    --hash=sha256:a4d6d37329e4a893e77d9ffa89e838dd2b45d5dc099984cf03c703ac8411bb82 \
+    # via -r requirements-dev.in
 pytest==6.1.2 \
     --hash=sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe \
     --hash=sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e \
-    # via -r requirements-dev.in
+    # via -r requirements-dev.in, pytest-mock
 regex==2020.11.13 \
     --hash=sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538 \
     --hash=sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4 \

--- a/tasks/veekun.py
+++ b/tasks/veekun.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 
 @init_task_wrapper()
 async def csv_to_sqlite(conn: Connection) -> None:
+    if conn.unittesting:
+        return
+
     latest_veekun_commit = ""
     try:
         latest_veekun_commit = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from queue import Queue
+from types import TracebackType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+)
+
+import pytest
+from sqlalchemy import MetaData, create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+from websockets import ConnectionClosedOK
+
+import databases.database as d
+import databases.logs as l
+from connection import Connection
+from database import Database
+
+if TYPE_CHECKING:
+    BaseMessagesQueue = Queue[Tuple[int, str]]  # pylint: disable=unsubscriptable-object
+else:
+    BaseMessagesQueue = Queue
+
+
+database_metadata: Dict[str, Any] = {
+    "database": d.db.metadata,
+    "logs": l.db.metadata,
+}
+
+
+class MessagesQueue(BaseMessagesQueue):
+    def add_messages(self, *items: List[str]) -> None:
+        for item in items:
+            self.put((0, "\n".join(item)))
+
+        self.put((1, ""))  # await conn._parse_message() tasks
+        self.join()
+
+    def close(self) -> None:
+        self.put((2, ""))  # close fake websocket connection
+
+
+@pytest.fixture()
+def mock_connection(
+    mocker,
+) -> Callable[[], Tuple[Connection, MessagesQueue]]:
+    def make_mock_connection(
+        *,
+        url: str = "ws://localhost:80/showdown/websocket",
+        username: str = "cerbottana",
+        password: str = "",
+        avatar: str = "",
+        statustext: str = "",
+        rooms: Optional[List[str]] = None,
+        private_rooms: Optional[List[str]] = None,
+        main_room: Optional[str] = None,
+        command_character: str = ".",
+        administrators: Optional[List[str]] = None,
+        domain: str = "http://localhost:8080/",
+    ) -> Tuple[Connection, MessagesQueue]:
+        class MockProtocol:
+            def __init__(self, messages: MessagesQueue) -> None:
+                self.messages = messages
+
+            def __await__(self) -> "MockProtocol":
+                return self
+
+            async def __aiter__(self) -> AsyncIterator[str]:
+                try:
+                    while True:
+                        msg = await self.recv()
+                        if msg:
+                            yield msg
+                except ConnectionClosedOK:
+                    return
+
+            async def recv(self) -> str:
+                msg_type, msg = self.messages.get()
+
+                if msg_type == 0:
+                    pass
+                elif msg_type == 1:
+                    # await conn._parse_message() tasks
+                    await asyncio.gather(
+                        *[  # pylint: disable=protected-access
+                            task
+                            for task in asyncio.all_tasks(conn.loop)
+                            if task._coro.__name__ == "_parse_message"  # type: ignore
+                        ]
+                    )
+                elif msg_type == 2:
+                    raise ConnectionClosedOK(1000, "Connection closed")
+
+                self.messages.task_done()
+                return msg
+
+            async def send(self, message: str) -> None:
+                pass
+
+        class MockConnect:
+            def __init__(self, url: str, **kwargs: Any) -> None:
+                pass
+
+            # async with connect(...)
+
+            async def __aenter__(self) -> MockProtocol:
+                return await self
+
+            async def __aexit__(
+                self,
+                exc_type: Optional[Type[BaseException]],
+                exc_value: Optional[BaseException],
+                traceback: Optional[TracebackType],
+            ) -> None:
+                pass
+
+            # await connect(...)
+
+            def __await__(self) -> Generator[Any, None, MockProtocol]:
+                # Create a suitable iterator by calling __await__ on a coroutine.
+                return self.__await_impl__().__await__()
+
+            async def __await_impl__(self) -> MockProtocol:
+                return MockProtocol(queue)
+
+        mocker.patch("websockets.connect", MockConnect)
+
+        database_instances: Dict[str, Database] = {}
+
+        def mock_database_init(self, dbname: str) -> None:
+            self.engine = create_engine("sqlite://")  # :memory: database
+            self.metadata = MetaData(bind=self.engine)
+            self.session_factory = sessionmaker(bind=self.engine)
+            self.Session = scoped_session(self.session_factory)
+            database_instances[dbname] = self
+
+        @classmethod  # type: ignore
+        def mock_database_open(cls, dbname: str = "database") -> Database:
+            if dbname not in database_instances:
+                cls(dbname)  # pylint: disable=too-many-function-args
+                if dbname in database_metadata:
+                    # Create schemas
+                    database_metadata[dbname].create_all(
+                        database_instances[dbname].engine
+                    )
+            return database_instances[dbname]
+
+        mocker.patch.object(Database, "__init__", mock_database_init)
+        mocker.patch.object(Database, "open", mock_database_open)
+
+        queue: MessagesQueue = MessagesQueue()
+
+        conn = Connection(
+            url,
+            username,
+            password,
+            avatar,
+            statustext,
+            rooms or [],
+            private_rooms or [],
+            main_room,
+            command_character,
+            administrators or [],
+            domain,
+            True,  # unittesting
+        )
+
+        threading.Thread(target=conn.open_connection).start()
+
+        queue.add_messages(["|updateuser|*cerbottana|1|0|{}"])
+
+        return (conn, queue)
+
+    return make_mock_connection

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -1,0 +1,127 @@
+from models.room import Room
+from models.user import User
+
+
+def test_room(mock_connection) -> None:
+    conn, queue = mock_connection()
+
+    # Join a room with only an user in it
+    queue.add_messages(
+        [
+            ">room1",
+            "|init|chat",
+            "|title|Room 1",
+            "|users|1,*cerbottana",
+            "|:|1500000000",
+        ]
+    )
+
+    room1 = Room.get(conn, "room1")
+
+    # Check if the room has been added to the list of the rooms (lobby is special here)
+    assert set(conn.rooms.keys()) == {"lobby", "room1"}
+    # Check the room title
+    assert room1.title == "Room 1"
+    # Check if the only user in the room has been added to the room
+    assert User.get(conn, "cerbottana") in room1
+
+    # Users enter the room
+    queue.add_messages(
+        [
+            ">room1",
+            "|j| User 1",
+        ],
+        [
+            ">room1",
+            "|J| User 2",
+        ],
+        [
+            ">room1",
+            "|join| User 3",
+        ],
+    )
+    assert User.get(conn, "user1") in room1
+    assert User.get(conn, "user2") in room1
+    assert User.get(conn, "user3") in room1
+
+    # Users change names
+    queue.add_messages(
+        [
+            ">room1",
+            "|n| User 4|user1",
+        ],
+        [
+            ">room1",
+            "|N| User 5|user2",
+        ],
+        [
+            ">room1",
+            "|name| User 6|user3",
+        ],
+    )
+    assert User.get(conn, "user1") not in room1
+    assert User.get(conn, "user2") not in room1
+    assert User.get(conn, "user3") not in room1
+    assert User.get(conn, "user4") in room1
+    assert User.get(conn, "user5") in room1
+    assert User.get(conn, "user6") in room1
+
+    # Users change names without changing userid
+    queue.add_messages(
+        [
+            ">room1",
+            "|n| USER 4|user4",
+        ],
+        [
+            ">room1",
+            "|N| USER 5|user5",
+        ],
+        [
+            ">room1",
+            "|name| USER 6|user6",
+        ],
+    )
+    assert User.get(conn, "user4") in room1
+    assert User.get(conn, "user5") in room1
+    assert User.get(conn, "user6") in room1
+
+    # Users leave the room
+    queue.add_messages(
+        [
+            ">room1",
+            "|l| User 4",
+        ],
+        [
+            ">room1",
+            "|L| User 5",
+        ],
+        [
+            ">room1",
+            "|leave| User 6",
+        ],
+    )
+    assert User.get(conn, "user4") not in room1
+    assert User.get(conn, "user5") not in room1
+    assert User.get(conn, "user6") not in room1
+
+    # Global and room rank
+    queue.add_messages(
+        [
+            "|queryresponse|userdetails|{"
+            + '  "id": "cerbottana",'
+            + '  "userid": "cerbottana",'
+            + '  "name": "cerbottana",'
+            + '  "avatar": "supernerd",'
+            + '  "group": "+",'
+            + '  "autoconfirmed": true,'
+            + '  "status": "",'
+            + '  "rooms": {'
+            + '    "*room1": {}'
+            + "  }"
+            + "}",
+        ]
+    )
+    assert User.get(conn, "cerbottana").global_rank == "+"
+    assert User.get(conn, "cerbottana").rank(room1) == "*"
+
+    queue.close()


### PR DESCRIPTION
This adds `pytest-mock` as a dependency to mock the websocket connection.
An additional `unittesting` parameter has been added to `Connection`, for now only used to skip the generation of `veekun.sqlite`, which is quite slow.
The last commit contains some tests for `handlers/room.py`.