### PR TITLE
Determine whether rooms are private dynamically

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -23,12 +23,8 @@ PASSWORD=mypassword
 ## STATUSTEXT: PS status text.
 # STATUSTEXT=statustext
 
-## ROOMS: List of public rooms joined at startup (roomids separated by commas).
+## ROOMS: List of rooms joined at startup (roomids separated by commas).
 # ROOMS=lobby
-
-## PRIVATE_ROOMS: List of private rooms joined at startup (roomids separated by
-## commas).
-# PRIVATE_ROOMS=myprivateroom
 
 ## MAIN_ROOM: Room used by `.dashboard`.
 # MAIN_ROOM=lobby

--- a/app.py
+++ b/app.py
@@ -38,7 +38,6 @@ def main() -> None:
         env("AVATAR", ""),
         env("STATUSTEXT", ""),
         env.list("ROOMS", []),
-        env.list("PRIVATE_ROOMS", []),
         env("MAIN_ROOM", None),
         env("COMMAND_CHARACTER"),
         env.list("ADMINISTRATORS", []),

--- a/connection.py
+++ b/connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 from time import time
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
 from weakref import WeakValueDictionary
 
 import websockets
@@ -29,7 +29,6 @@ class Connection:
         avatar: str,
         statustext: str,
         rooms: List[str],
-        private_rooms: List[str],
         main_room: Optional[str],
         command_character: str,
         administrators: List[str],
@@ -42,15 +41,15 @@ class Connection:
         self.avatar = avatar
         self.statustext = statustext
         self.rooms: Dict[RoomId, Room] = {}  # roomid, Room
-        for roomid in [utils.to_room_id(room) for room in rooms]:
-            self.rooms[roomid] = Room(self, roomid, is_private=False, autojoin=True)
-        for roomid in [utils.to_room_id(room) for room in private_rooms]:
-            self.rooms[roomid] = Room(self, roomid, is_private=True, autojoin=True)
+        for roomname in rooms:
+            roomid = utils.to_room_id(roomname)
+            self.rooms[roomid] = Room(self, roomid, autojoin=True)
         self.main_room = Room.get(self, main_room) if main_room else None
         self.command_character = command_character
         self.administrators = [utils.to_user_id(user) for user in administrators]
         self.domain = domain
         self.unittesting = unittesting
+        self.public_roomids: Set[str] = set()
         self.users: WeakValueDictionary[  # pylint: disable=unsubscriptable-object
             UserId, User
         ] = WeakValueDictionary()

--- a/handlers/login.py
+++ b/handlers/login.py
@@ -39,6 +39,9 @@ async def challstr(conn: Connection, room: Room, *args: str) -> None:
     if assertion:
         await conn.send(f"|/trn {conn.username},0,{assertion}")
 
+    # Startup commands
+    await conn.send("|/cmd rooms")
+
 
 @handler_wrapper(["updateuser"])
 async def updateuser(conn: Connection, room: Room, *args: str) -> None:

--- a/plugins/tcg.py
+++ b/plugins/tcg.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 import re
 import urllib
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 import aiohttp
 
 import utils
 from plugins import command_wrapper
+from typedefs import JsonDict
 
 if TYPE_CHECKING:
     from models.message import Message
-
-
-JsonDict = Dict[str, Any]  # type: ignore[misc]
 
 
 async def query_scryfall(url: str, resp_type: str) -> Optional[JsonDict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,6 @@ def mock_connection(
             avatar,
             statustext,
             rooms or [],
-            private_rooms or [],
             main_room,
             command_character,
             administrators or [],

--- a/tests/plugins/test_tcg.py
+++ b/tests/plugins/test_tcg.py
@@ -31,7 +31,7 @@ def test_thumbnail_layout(layout: str) -> None:
 
 def test_thumbnail_missing_image_uris() -> None:
     """Tests whether a card with missing image_uris triggers a fallback."""
-    card_json: tcg.JsonDict = {
+    card_json = {
         "name": "Dummy Card Name",
         "scryfall_uri": "https://dummy.url/",
     }

--- a/typedefs.py
+++ b/typedefs.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from typing_extensions import Literal, NewType, TypedDict
 
 RoomId = NewType("RoomId", str)
@@ -5,6 +7,8 @@ UserId = NewType("UserId", str)
 Role = Literal[
     "admin", "owner", "bot", "host", "mod", "driver", "player", "voice", "prizewinner"
 ]
+
+JsonDict = Dict[str, Any]  # type: ignore[misc]
 
 TiersDict = TypedDict(
     "TiersDict",


### PR DESCRIPTION
This requires changes to your `.env` file: `PRIVATE_ROOMS` is now deprecated and both public and private rooms are listed in `ROOMS`.