### PR TITLE
Modchat: Ignore gstaff

### DIFF
--- a/models/room.py
+++ b/models/room.py
@@ -114,7 +114,7 @@ class Room:
             rank = self._users[user] if user in self._users else " "
         self._users[user] = rank
 
-        if user.has_role("driver", self):
+        if user.has_role("driver", self, ignore_grole=True):
             if not user.idle:
                 self.no_mods_online = None
             else:
@@ -148,7 +148,7 @@ class Room:
         for user in self._users:
             if user.idle:
                 continue
-            if user.has_role("driver", self):
+            if user.has_role("driver", self, ignore_grole=True):
                 self.no_mods_online = None
                 return
             self.no_mods_online = time()

--- a/models/user.py
+++ b/models/user.py
@@ -87,7 +87,7 @@ class User:
         """
         return room.users[self] if self in room else None
 
-    def has_role(self, role: Role, room: Room) -> bool:
+    def has_role(self, role: Role, room: Room, ignore_grole: bool = False) -> bool:
         """Check if user has a PS room role or higher.
 
         Higher global roles ovveride room roles.
@@ -95,11 +95,16 @@ class User:
         Args:
             role (Role): PS role (i.e. "voice", "driver").
             room (Room): Room to check.
+            ignore_grole (bool, optional): True if global roles should be ignored.
 
         Returns:
             bool: True if user meets the required criteria.
         """
-        if self.global_rank and utils.has_role(role, self.global_rank):
+        if (
+            not ignore_grole
+            and self.global_rank
+            and utils.has_role(role, self.global_rank)
+        ):
             return True
 
         room_rank = self.rank(room)

--- a/tests/handlers/test_modchat.py
+++ b/tests/handlers/test_modchat.py
@@ -327,4 +327,29 @@ def test_modchat(mock_connection) -> None:
     )
     assert room1.no_mods_online is not None
 
+    # a gmod enters the room, no_mods_online should still be not None because gstaff is
+    # ignored
+    recv_queue.add_messages(
+        [
+            ">room1",
+            "|j|@gmod",
+        ],
+        [
+            "|queryresponse|userdetails|{"
+            + "  "
+            + '  "id": "gmod",'
+            + '  "userid": "gmod",'
+            + '  "name": "gmod",'
+            + '  "avatar": "1",'
+            + '  "group": "@",'
+            + '  "autoconfirmed": true,'
+            + '  "status": "",'
+            + '  "rooms": {'
+            + '    "room1": {}'
+            + "  }"
+            + "}"
+        ],
+    )
+    assert room1.no_mods_online is not None
+
     recv_queue.close()


### PR DESCRIPTION
We should ignore gstaff for modchat purposes and still set it if it's really late and there aren't any active roomstaff members.

As I mentioned privately, this feature appeared to be bugged at times, but this PR only changes the detected "required role" without touching the underlying logic, so it shouldn't be problematic to merge.