### PR TITLE
Add parameters to decorators

### DIFF
--- a/models/room.py
+++ b/models/room.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import datetime
+from textwrap import shorten
 from time import time
 from typing import TYPE_CHECKING, Deque, Dict, Optional
 
@@ -200,6 +201,22 @@ class Room:
         if page_room:
             pageid += "0" + page_room.roomid
         await self.send(f"<<view-bot-{utils.to_user_id(self.conn.username)}-{pageid}>>")
+
+    async def send_modnote(self, action: str, user: User, note: str = "") -> None:
+        """Adds a modnote to a room.
+
+        Args:
+            action (str): id of the action performed.
+            user (User): User who performed the action.
+            note (str, optional): additional notes.
+        """
+        if not self.roombot:
+            return
+
+        arg = f"[{action}] {user.userid}"
+        if note:
+            arg += f": {note}"
+        await self.send(f"/modnote {shorten(arg, 300)}", False)
 
     @classmethod
     def get(cls, conn: Connection, room: str) -> Room:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -44,9 +44,9 @@ class Command:
     def __init__(
         self,
         func: CommandFunc,
-        aliases: Tuple[str, ...] = (),
-        helpstr: str = "",
-        is_unlisted: bool = False,
+        aliases: Tuple[str, ...],
+        helpstr: str,
+        is_unlisted: bool,
     ) -> None:
         self.name = func.__name__
         self.callback = func
@@ -75,27 +75,55 @@ class Command:
         return {k: d[k] for k in sorted(d)}  # python 3.7+
 
 
-def scope_checker(func: CommandFunc) -> CommandFunc:
+def command_check_permission(
+    func: CommandFunc,
+    required_rank: Role,
+    allow_pm: bool,
+    main_room_only: bool,
+    parametrize_room: bool,
+) -> CommandFunc:
     @wraps(func)
-    async def scope_wrapper(msg: Message) -> None:
-        if msg.room is not None and not msg.user.has_role("voice", msg.room):
+    async def wrapper(msg: Message) -> None:
+        if main_room_only and not msg.user.has_role(required_rank, msg.conn.main_room):
             return
+
+        if not allow_pm and msg.room is None:
+            return
+
+        if parametrize_room:
+            if msg.user not in msg.parametrized_room.users or not msg.user.has_role(
+                required_rank, msg.parametrized_room
+            ):
+                return
+        elif msg.room is not None and not msg.user.has_role(required_rank, msg.room):
+            return
+
         await func(msg)
 
-    return scope_wrapper
+    return wrapper
 
 
 def command_wrapper(
-    aliases: Tuple[str, ...] = (), helpstr: str = "", is_unlisted: bool = False
+    aliases: Tuple[str, ...] = (),
+    helpstr: str = "",
+    is_unlisted: bool = False,
+    required_rank: Role = "voice",
+    allow_pm: bool = True,
+    main_room_only: bool = False,
+    parametrize_room: bool = False,
 ) -> Callable[[CommandFunc], Command]:
     def cls_wrapper(func: CommandFunc) -> Command:
-        func = scope_checker(func)  # manual decorator binding
+        func = command_check_permission(
+            func, required_rank, allow_pm, main_room_only, parametrize_room
+        )
+        if parametrize_room:
+            func = parametrize_room_wrapper(func)
         return Command(func, aliases, helpstr, is_unlisted)
 
     return cls_wrapper
 
 
-def parametrize_room(func: CommandFunc) -> CommandFunc:
+def parametrize_room_wrapper(func: CommandFunc) -> CommandFunc:
     """
     Enriches a command depending on its context:
     (1) If it's used in a room, it saves such room in msg.parametrized_room.
@@ -183,22 +211,28 @@ def htmlpage_wrapper(
 routes: List[Tuple[RouteFunc, str, Optional[Iterable[str]]]] = []
 
 
-def route_require_driver(func: RouteFunc) -> RouteFunc:
+def route_check_permission(func: RouteFunc, required_rank: Optional[Role]) -> RouteFunc:
     @wraps(func)
     def wrapper(**kwargs: str) -> str:
-        if not utils.has_role("driver", web_session.get("_rank")):
+        rank_check = kwargs.get("room", "_rank")
+        if required_rank is None:
+            if rank_check not in web_session:
+                abort(401)
+        elif not utils.has_role(required_rank, web_session.get(rank_check)):
             abort(401)
+
         return func(**kwargs)
 
     return wrapper
 
 
 def route_wrapper(
-    rule: str, methods: Optional[Iterable[str]] = None, require_driver: bool = False
+    rule: str,
+    methods: Optional[Iterable[str]] = None,
+    required_rank: Optional[Role] = None,
 ) -> Callable[[RouteFunc], RouteFunc]:
     def wrapper(func: RouteFunc) -> RouteFunc:
-        if require_driver:
-            func = route_require_driver(func)  # manual decorator binding
+        func = route_check_permission(func, required_rank)
         routes.append((func, rule, methods))
         return func
 

--- a/plugins/chatlog.py
+++ b/plugins/chatlog.py
@@ -14,7 +14,7 @@ import utils
 from database import Database
 from handlers import handler_wrapper
 from models.room import Room
-from plugins import command_wrapper, parametrize_room, route_wrapper
+from plugins import command_wrapper, route_wrapper
 from tasks import recurring_task_wrapper
 
 if TYPE_CHECKING:
@@ -120,8 +120,7 @@ async def logger(conn: Connection, room: Room, *args: str) -> None:
         )
 
 
-@command_wrapper()
-@parametrize_room
+@command_wrapper(parametrize_room=True)
 async def getlogs(msg: Message) -> None:
     if msg.user.userid in msg.conn.administrators:
         logsroom = msg.parametrized_room.roomid
@@ -129,18 +128,11 @@ async def getlogs(msg: Message) -> None:
         await msg.conn.send(f"|/join view-chatlog-{logsroom}--{date}")
 
 
-@command_wrapper(aliases=("linecount",))
-@parametrize_room
+@command_wrapper(aliases=("linecount",), required_rank="driver", parametrize_room=True)
 async def linecounts(msg: Message) -> None:
     logsroom = msg.parametrized_room.roomid
 
-    users = msg.parametrized_room.users
-    if msg.user not in users:
-        return
-
-    rank = users[msg.user]
-    if not utils.has_role("driver", rank):
-        return
+    rank = msg.parametrized_room.users[msg.user]
 
     token_id = utils.create_token({logsroom: rank}, 1)
 
@@ -152,18 +144,11 @@ async def linecounts(msg: Message) -> None:
     await msg.user.send(message)
 
 
-@command_wrapper()
-@parametrize_room
+@command_wrapper(required_rank="driver", parametrize_room=True)
 async def topusers(msg: Message) -> None:
     logsroom = msg.parametrized_room.roomid
 
-    users = msg.parametrized_room.users
-    if msg.user not in users:
-        return
-
-    rank = users[msg.user]
-    if not utils.has_role("driver", rank):
-        return
+    rank = msg.parametrized_room.users[msg.user]
 
     token_id = utils.create_token({logsroom: rank}, 1)
 

--- a/plugins/dashboard.py
+++ b/plugins/dashboard.py
@@ -8,11 +8,8 @@ if TYPE_CHECKING:
     from models.message import Message
 
 
-@command_wrapper(aliases=("token",))
+@command_wrapper(aliases=("token",), required_rank="driver", main_room_only=True)
 async def dashboard(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     phrase = (
         "``.dashboard`` è stato rimosso, "
         "per gestire le badge di un utente usa ``.badges <utente>``, "

--- a/plugins/eightball.py
+++ b/plugins/eightball.py
@@ -30,11 +30,8 @@ async def eightball(msg: Message) -> None:
         await msg.reply(answer)
 
 
-@command_wrapper(aliases=("8ballanswers",))
+@command_wrapper(aliases=("8ballanswers",), required_rank="driver", main_room_only=True)
 async def eightballanswers(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     try:
         page = int(msg.arg)
     except ValueError:
@@ -43,11 +40,12 @@ async def eightballanswers(msg: Message) -> None:
     await msg.user.send_htmlpage("eightball", msg.conn.main_room, page)
 
 
-@command_wrapper(aliases=("add8ballanswer", "neweightballanswer", "new8ballanswer"))
+@command_wrapper(
+    aliases=("add8ballanswer", "neweightballanswer", "new8ballanswer"),
+    required_rank="driver",
+    main_room_only=True,
+)
 async def addeightballanswer(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     if not msg.arg:
         await msg.reply("Cosa devo salvare?")
         return
@@ -76,12 +74,11 @@ async def addeightballanswer(msg: Message) -> None:
         "del8ballanswer",
         "rmeightballanswer",
         "rm8ballanswer",
-    )
+    ),
+    required_rank="driver",
+    main_room_only=True,
 )
 async def removeeightballanswer(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     if not msg.arg:
         await msg.reply("Che risposta devo cancellare?")
         return
@@ -96,11 +93,8 @@ async def removeeightballanswer(msg: Message) -> None:
             await msg.reply("Risposta inesistente.")
 
 
-@command_wrapper()
+@command_wrapper(required_rank="driver", main_room_only=True)
 async def removeeightballanswerid(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     if len(msg.args) != 2:
         return
 

--- a/plugins/guessthemon.py
+++ b/plugins/guessthemon.py
@@ -19,11 +19,9 @@ if TYPE_CHECKING:
 @command_wrapper(
     aliases=("gtm", "hangmanpokemon", "pokemonhangman"),
     helpstr="Indovina un pokemon da una sua entry del pokedex!",
+    allow_pm=False,
 )
 async def guessthemon(msg: Message) -> None:
-    if msg.room is None:
-        return
-
     db = Database.open("veekun")
     with db.get_session() as session:
         # Retrieve a random pokemon

--- a/plugins/misc.py
+++ b/plugins/misc.py
@@ -4,41 +4,36 @@ import random
 from typing import TYPE_CHECKING
 
 import utils
-from plugins import command_wrapper, parametrize_room
+from plugins import command_wrapper
 
 if TYPE_CHECKING:
     from models.message import Message
 
 
 @command_wrapper(
-    aliases=("randomcaio",), helpstr="Saluta un utente a caso presente nella room."
+    aliases=("randomcaio",),
+    helpstr="Saluta un utente a caso presente nella room.",
+    parametrize_room=True,
 )
 async def randcaio(msg: Message) -> None:
-    if msg.room is None:
-        return
-    user = random.choice(list(msg.room.users.keys()))
+    user = random.choice(list(msg.parametrized_room.users.keys()))
     await msg.reply(f"caio {user}")
 
 
 @command_wrapper(
-    aliases=("randomuser",), helpstr="Seleziona un utente a caso presente nella room."
+    aliases=("randomuser",),
+    helpstr="Seleziona un utente a caso presente nella room.",
+    parametrize_room=True,
 )
 async def randuser(msg: Message) -> None:
-    if msg.room is None:
-        return
-    user = random.choice(list(msg.room.users.keys()))
+    user = random.choice(list(msg.parametrized_room.users.keys()))
     await msg.reply(f"{user}")
 
 
-@command_wrapper()
-@parametrize_room
+@command_wrapper(required_rank="driver", parametrize_room=True)
 async def tell(msg: Message) -> None:
     if not msg.arg:
         await msg.reply("Cosa devo inviare?")
-        return
-
-    if not msg.user.has_role("driver", msg.parametrized_room):
-        await msg.reply("Devi essere almeno driver")
         return
 
     author = msg.user.roomname(msg.parametrized_room)
@@ -51,11 +46,8 @@ async def tell(msg: Message) -> None:
     await msg.parametrized_room.send_htmlbox(html)
 
 
-@command_wrapper(helpstr="<i>[blitz]</i> Avvia una partita di UNO.")
+@command_wrapper(helpstr="<i>[blitz]</i> Avvia una partita di UNO.", allow_pm=False)
 async def uno(msg: Message) -> None:
-    if msg.room is None:
-        return
-
     blitz_keywords = ("blitz", "fast", "veloce")
     timer = 5 if msg.arg.lower() in blitz_keywords else 30
 

--- a/plugins/profile.py
+++ b/plugins/profile.py
@@ -110,10 +110,8 @@ async def clearprofile(msg: Message) -> None:
     await msg.reply("Frase rimossa")
 
 
-@command_wrapper(aliases=("badges",))
+@command_wrapper(aliases=("badges",), required_rank="driver", main_room_only=True)
 async def badge(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
     admin_rank = msg.user.rank(msg.conn.main_room)
 
     rooms: Dict[str, str] = {}
@@ -127,7 +125,7 @@ async def badge(msg: Message) -> None:
     await msg.user.send(f"{msg.conn.domain}badges/{userid}?token={token_id}")
 
 
-@route_wrapper("/badges/<userid>", methods=("GET", "POST"), require_driver=True)
+@route_wrapper("/badges/<userid>", methods=("GET", "POST"), required_rank="driver")
 def badges_route(userid: str) -> str:
     db = Database.open()
 
@@ -165,19 +163,13 @@ def badges_route(userid: str) -> str:
         return render_template("badges.html", user=user, badges=badges)
 
 
-@command_wrapper()
+@command_wrapper(required_rank="driver", main_room_only=True)
 async def pendingdescriptions(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     await msg.user.send_htmlpage("pendingdescriptions", msg.conn.main_room)
 
 
-@command_wrapper()
+@command_wrapper(required_rank="driver", main_room_only=True)
 async def approvaprofilo(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     db = Database.open()
 
     with db.get_session() as session:
@@ -194,11 +186,8 @@ async def approvaprofilo(msg: Message) -> None:
     await msg.user.send_htmlpage("pendingdescriptions", msg.conn.main_room)
 
 
-@command_wrapper()
+@command_wrapper(required_rank="driver", main_room_only=True)
 async def rifiutaprofilo(msg: Message) -> None:
-    if not msg.user.has_role("driver", msg.conn.main_room):
-        return
-
     db = Database.open()
 
     with db.get_session() as session:

--- a/plugins/repeats.py
+++ b/plugins/repeats.py
@@ -252,7 +252,10 @@ async def repeat(msg: Message) -> None:
             return
 
     # start repeat and report result
-    if not instance.start():
+    if instance.start():
+        if msg.room is None:
+            await msg.parametrized_room.send_modnote("REPEAT ADDED", msg.user, phrase)
+    else:
         await msg.reply(errmsg)
 
 
@@ -276,6 +279,11 @@ async def stoprepeat(msg: Message) -> None:
         instance.stop()
 
     await msg.reply("Fatto.")
+    if msg.room is None:
+        if query is None:
+            await msg.parametrized_room.send_modnote("REPEATS CLEARED", msg.user)
+        else:
+            await msg.parametrized_room.send_modnote("REPEAT REMOVED", msg.user, query)
 
 
 @command_wrapper(aliases=("repeats",), required_rank="driver", parametrize_room=True)

--- a/plugins/shitpost.py
+++ b/plugins/shitpost.py
@@ -11,14 +11,11 @@ if TYPE_CHECKING:
     from models.message import Message
 
 
-@command_wrapper(
-    aliases=("say",),
-    helpstr="FOR THE MIMMMSSS",
-    is_unlisted=True,
-)
+@command_wrapper(aliases=("say",), is_unlisted=True, allow_pm=False)
 async def shitpost(msg: Message) -> None:
     if msg.room is None:
         return
+
     phrase = utils.remove_accents(msg.arg.strip())
     if len(phrase) > 50:
         await msg.reply("Testo troppo lungo")
@@ -51,7 +48,7 @@ async def shitpost(msg: Message) -> None:
     await msg.reply_htmlbox(html.format(text0, text1, text2))
 
 
-@command_wrapper(aliases=("meme", "memes", "mims"))
+@command_wrapper(aliases=("meme", "memes", "mims"), is_unlisted=True, allow_pm=False)
 async def memes(msg: Message) -> None:
     if msg.room is None or not msg.room.is_private:
         return

--- a/plugins/tcg.py
+++ b/plugins/tcg.py
@@ -85,11 +85,9 @@ def to_card_thumbnail(card_json: JsonDict) -> str:
 @command_wrapper(
     aliases=("carta", "magic", "mtg"),
     helpstr="Mostra una carta di Magic: the Gathering",
+    allow_pm=False,
 )
 async def card(msg: Message) -> None:
-    if msg.room is None:
-        return
-
     if not msg.arg:
         await msg.reply("Che carta devo cercare?")
         return
@@ -132,11 +130,9 @@ async def card(msg: Message) -> None:
 @command_wrapper(
     aliases=("cardhangman", "gtc", "hangmancard"),
     helpstr="Indovina una carta di Magic: the Gathering!",
+    allow_pm=False,
 )
 async def guessthecard(msg: Message) -> None:
-    if msg.room is None:
-        return
-
     filters = (
         "legal:standard",
         "-type:basic",  # Basic lands
@@ -168,11 +164,8 @@ async def guessthecard(msg: Message) -> None:
     await msg.reply(f"/hangman create {cardname}, {hint}", False)
 
 
-@command_wrapper(aliases=("randomcard",))
+@command_wrapper(aliases=("randomcard",), allow_pm=False)
 async def randcard(msg: Message) -> None:
-    if msg.room is None:
-        return
-
     url = "https://api.scryfall.com/cards/random"
     if msg.arg:
         # Users can input an optional query to restrict the cardpool.

--- a/plugins/tours.py
+++ b/plugins/tours.py
@@ -53,11 +53,10 @@ async def create_tour(
     aliases=("randomtour",),
     helpstr="Avvia un torneo di una tier scelta a caso tra quelle con team random",
     is_unlisted=True,
+    required_rank="driver",
+    allow_pm=False,
 )
 async def randtour(msg: Message) -> None:
-    if msg.room is None or not msg.user.has_role("driver", msg.room):
-        return
-
     tiers = [x["name"] for x in msg.conn.tiers if x["random"]]
 
     formatid = random.choice(tiers)
@@ -97,11 +96,10 @@ async def randtour(msg: Message) -> None:
 # --- Commands for tours with custom rules ---
 
 
-@command_wrapper(aliases=("monopoke",), is_unlisted=True)
+@command_wrapper(
+    aliases=("monopoke",), is_unlisted=True, required_rank="driver", allow_pm=False
+)
 async def monopoketour(msg: Message) -> None:
-    if msg.room is None or not msg.user.has_role("driver", msg.room):
-        return
-
     if len(msg.args) != 1:
         await msg.reply("Specifica un (solo) Pokémon")
         return
@@ -116,12 +114,12 @@ async def monopoketour(msg: Message) -> None:
 
 
 @command_wrapper(
-    helpstr="<i> poke1, poke2, ... </i> Avvia un randpoketour.", is_unlisted=True
+    helpstr="<i> poke1, poke2, ... </i> Avvia un randpoketour.",
+    is_unlisted=True,
+    required_rank="driver",
+    allow_pm=False,
 )
 async def randpoketour(msg: Message) -> None:
-    if msg.room is None or not msg.user.has_role("driver", msg.room):
-        return
-
     if not msg.arg:
         await msg.reply("Inserisci almeno un Pokémon")
         return
@@ -148,11 +146,10 @@ async def randpoketour(msg: Message) -> None:
     aliases=("sibb",),
     helpstr="Avvia un torneo Super Italian Bros. Brawl",
     is_unlisted=True,
+    required_rank="driver",
+    allow_pm=False,
 )
 async def waffletour(msg: Message) -> None:
-    if msg.room is None or not msg.user.has_role("driver", msg.room):
-        return
-
     name = "Super Italian Bros. Brawl"
     rules = [
         "Cancel Mod",

--- a/tests/plugins/test_parametrize_room.py
+++ b/tests/plugins/test_parametrize_room.py
@@ -1,0 +1,40 @@
+import ast
+import inspect
+
+from plugins import commands
+
+
+def test_parametrize_room() -> None:
+    """Checks if msg.parametrized_room is only used in properly decorated commands."""
+    for command in commands:
+        func_source = inspect.getsource(commands[command].callback)
+        func_ast = ast.parse(func_source)
+
+        decorator = next(
+            i
+            for i in func_ast.body[0].decorator_list  # type: ignore[attr-defined]
+            if i.func.id == "command_wrapper"
+        )
+        has_parametrize_room = next(
+            (
+                i
+                for i in decorator.keywords
+                if i.arg == "parametrize_room" and i.value.value
+            ),
+            False,
+        )
+        if not has_parametrize_room:
+            uses_parametrized_room = next(
+                (
+                    i
+                    for i in ast.walk(func_ast.body[0])
+                    if isinstance(i, ast.Attribute)
+                    and isinstance(i.value, ast.Name)
+                    and i.value.id == "msg"
+                    and i.attr == "parametrized_room"
+                ),
+                False,
+            )
+            assert (
+                not uses_parametrized_room
+            ), f"{command} shouldn't use msg.parametrized_room"


### PR DESCRIPTION
This replaces #138 

I removed MessageDisallowPM, and with it the overload on command_wrapper.
These are the various things I did:
- I replaced `msg.room.send*` with `msg.reply*` everywhere. `create_tour` in the tours plugins now accepts a `Message` as its first parameter.
- `msg.room.language`/`msg.room.language_id`: I added these properties to `Message` as well, reading from `self.room` if it exists, with english as a default. I also moved the language table to utils.
- Everything previously disallowed in pm that can technically be done (basically everything excluding tours/hangman/uno, and `.shitpost`/`.memes`) is now available in pm as well (using parametrize_room). Repeats and quotes should be modified to log something using /modnote

I haven't tested anything yet, but I'm posting this already in case you have anything to comment on.