### PR TITLE
Check docstrings with darglint

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,2 @@
+[darglint]
+strictness=long

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
       run: isort --check .
     - name: Check formatting using black
       run: black --check .
+    - name: Check docstrings with darglint
+      run: find . -name '*.py' -not -path './.*' | xargs darglint -v 2
     - name: Test with mypy
       run: mypy .
     - name: Test with pylint

--- a/models/message.py
+++ b/models/message.py
@@ -79,7 +79,7 @@ class Message:
 
         Args:
             message (str): Text to be sent.
-            escape (bool, optional): True if PS commands should be escaped. Defaults to
+            escape (bool): True if PS commands should be escaped. Defaults to
                 True.
         """
         if self.room is None:
@@ -107,7 +107,7 @@ class Message:
         Args:
             pageid (str): id of the htmlpage.
             room (Room): Room to be passed to the function.
-            page (int, optional): Page number. Defaults to 1.
+            page (int): Page number. Defaults to 1.
         """
         if self.room is None:
             await self.user.send_htmlpage(pageid, room, page)

--- a/models/room.py
+++ b/models/room.py
@@ -27,7 +27,7 @@ class Room:
         conn (Connection): Used to access the websocket.
         roomid (str): Uniquely identifies a room, see utils.to_room_id.
         is_private (bool): True if room is unlisted/private.
-        autojoin (bool, optional): Whether the bot should join the room on startup.
+        autojoin (bool): Whether the bot should join the room on startup.
             Defaults to False.
         buffer (Deque[str]): Fixed list of the last room messages.
         language (str): Room language.
@@ -96,8 +96,8 @@ class Room:
 
         Args:
             user (User): User to add.
-            rank (Optional[str], optional): Room rank of user. Defaults to None if rank
-               is unchanged.
+            rank (Optional[str]): Room rank of user. Defaults to None if rank is
+                unchanged.
         """
         if not rank:
             rank = self._users[user] if user in self._users else " "
@@ -162,7 +162,7 @@ class Room:
 
         Args:
             message (str): Text to be sent.
-            escape (bool, optional): True if PS commands should be escaped. Defaults to
+            escape (bool): True if PS commands should be escaped. Defaults to
                 True.
         """
         if escape:
@@ -208,7 +208,7 @@ class Room:
         Args:
             action (str): id of the action performed.
             user (User): User who performed the action.
-            note (str, optional): additional notes.
+            note (str): additional notes.
         """
         if not self.roombot:
             return

--- a/models/user.py
+++ b/models/user.py
@@ -95,7 +95,7 @@ class User:
         Args:
             role (Role): PS role (i.e. "voice", "driver").
             room (Room): Room to check.
-            ignore_grole (bool, optional): True if global roles should be ignored.
+            ignore_grole (bool): True if global roles should be ignored.
 
         Returns:
             bool: True if user meets the required criteria.
@@ -143,7 +143,7 @@ class User:
 
         Args:
             message (str): Text to be sent.
-            escape (bool, optional): True if PS commands should be escaped. Defaults to
+            escape (bool): True if PS commands should be escaped. Defaults to
                 True.
         """
         if escape and message[0] == "/":
@@ -155,7 +155,7 @@ class User:
 
         Args:
             message (str): HTML to be sent.
-            simple_message (str, optional): Alt text. Defaults to a generic message.
+            simple_message (str): Alt text. Defaults to a generic message.
         """
         message = htmlmin.minify(message)
         room = self.can_pminfobox_to()
@@ -173,7 +173,7 @@ class User:
         Args:
             pageid (str): id of the htmlpage.
             page_room (Room): Room to be passed to the function.
-            page (int, optional): Page number. Defaults to 1.
+            page (int): Page number. Defaults to 1.
         """
         if pageid not in htmlpages:
             return

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 black
+darglint
 isort
 mypy
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,6 +74,10 @@ coverage==5.3.1 \
     --hash=sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7 \
     --hash=sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae \
     # via pytest-cov
+darglint==1.5.8 \
+    --hash=sha256:2e1012945a09d19a15cc87f9d15e7b14c18473ec9cf7769c641951b348de1353 \
+    --hash=sha256:529f4969029d5ff5f74bfec48adc14b6f003409141f722b6cc4b787dddc8a4dd \
+    # via -r requirements-dev.in
 importlib-metadata==3.3.0 \
     --hash=sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed \
     --hash=sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450 \

--- a/utils.py
+++ b/utils.py
@@ -87,7 +87,7 @@ def has_role(role: Role, user: str, strict_voice_check: bool = False) -> bool:
     Args:
         role (Role): PS role (i.e. "voice", "driver").
         user (str): User to check.
-        strict_voice_check (bool, optional): True if custom rank symbols should not be
+        strict_voice_check (bool): True if custom rank symbols should not be
             considered voice. Defaults to False.
 
     Returns:


### PR DESCRIPTION
This also removes the `(..., optional)` syntax that marks parameters with a default value, because it isn't supported by darglint.

The linter will allow one-line docstrings and multiline docstrings without _any_ arguments/returns/yields/etc. sections, such as the docstring of `parametrize_room` or `Repeat.pull_db`.
Basically if you actively choose to stray away from the Google docstring structure and write a verbose description you can, but if you write a streamlined docstring it will check for its correctness.

I kept the last 2 commits separated since we usually isolate commits that only add dependencies from actual code changes.
