### PR TITLE
Per room eightball answers

### DIFF
--- a/alembic/versions/21bfb4710834_per_room_eightball_answers.py
+++ b/alembic/versions/21bfb4710834_per_room_eightball_answers.py
@@ -1,0 +1,92 @@
+"""Per-room eightball answers
+
+Revision ID: 21bfb4710834
+Revises: f029c079628c
+Create Date: 2020-12-06 17:11:25.270563
+
+"""
+from environs import Env
+
+# pylint: skip-file
+from sqlalchemy import Column, Integer, MetaData, String, Table, UniqueConstraint
+from sqlalchemy.sql import column, select, table
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "21bfb4710834"
+down_revision = "f029c079628c"
+branch_labels = None
+depends_on = None
+
+
+env = Env()
+env.read_env()
+
+main_room = env("MAIN_ROOM")
+rooms = env.list("ROOMS", [])
+
+
+def upgrade():
+    meta = MetaData()
+
+    with op.batch_alter_table("eightball") as batch_op:
+        batch_op.add_column(
+            Column("roomid", String, nullable=False, server_default=main_room)
+        )
+
+    with op.batch_alter_table(
+        "eightball",
+        copy_from=Table(
+            "eightball",
+            meta,
+            Column("id", Integer, primary_key=True),
+            Column("answer", String, nullable=False),
+            Column("roomid", String, nullable=False),
+            UniqueConstraint(
+                "answer",
+                "roomid",
+                name="unique_answer_roomid",
+                sqlite_on_conflict="IGNORE",
+            ),
+        ),
+    ) as batch_op:
+        # dummy operation
+        batch_op.alter_column("id")
+
+    eightball = table(
+        "eightball",
+        Column("answer", String),
+        Column("roomid", String),
+    )
+
+    for room in set(rooms) - {main_room}:
+        op.execute(
+            eightball.insert().from_select(
+                ["answer", "roomid"],
+                select([eightball.c.answer, op.inline_literal(room)]).where(
+                    eightball.c.roomid == main_room
+                ),
+            )
+        )
+
+
+def downgrade():
+    meta = MetaData()
+
+    with op.batch_alter_table(
+        "eightball",
+        copy_from=Table(
+            "eightball",
+            meta,
+            Column("id", Integer, primary_key=True),
+            Column("answer", String, nullable=False),
+            UniqueConstraint(
+                "answer",
+                name="unique_answer",
+                sqlite_on_conflict="IGNORE",
+            ),
+        ),
+    ) as batch_op:
+        # dummy operation
+        batch_op.alter_column("id")

--- a/databases/database.py
+++ b/databases/database.py
@@ -21,10 +21,13 @@ class Badges(Base):
 
 class EightBall(Base):
     __tablename__ = "eightball"
-    __table_opts__ = (UniqueConstraint("answer", sqlite_on_conflict="IGNORE"),)
+    __table_opts__ = (
+        UniqueConstraint("answer", "roomid", sqlite_on_conflict="IGNORE"),
+    )
 
     id = Column(Integer, primary_key=True)
     answer = Column(String, nullable=False)
+    roomid = Column(String, nullable=False)
 
 
 class Quotes(Base):

--- a/plugins/eightball.py
+++ b/plugins/eightball.py
@@ -21,29 +21,36 @@ async def eightball(msg: Message) -> None:
     db = Database.open()
 
     with db.get_session() as session:
-        answers = session.query(d.EightBall).all()
+        language_name = msg.language
+        if language_name not in DEFAULT_ANSWERS:
+            language_name = "English"
+        answers = DEFAULT_ANSWERS[language_name]
 
-        if not answers:
-            return
+        if msg.room:
+            custom_answers = (
+                session.query(d.EightBall).filter_by(roomid=msg.room.roomid).all()
+            )
+            answers.extend([i.answer for i in custom_answers])
 
-        answer = random.choice(answers).answer
-        await msg.reply(answer)
+        await msg.reply(random.choice(answers))
 
 
-@command_wrapper(aliases=("8ballanswers",), required_rank="driver", main_room_only=True)
+@command_wrapper(
+    aliases=("8ballanswers",), required_rank="driver", parametrize_room=True
+)
 async def eightballanswers(msg: Message) -> None:
     try:
         page = int(msg.arg)
     except ValueError:
         page = 1
 
-    await msg.user.send_htmlpage("eightball", msg.conn.main_room, page)
+    await msg.user.send_htmlpage("eightball", msg.parametrized_room, page)
 
 
 @command_wrapper(
     aliases=("add8ballanswer", "neweightballanswer", "new8ballanswer"),
     required_rank="driver",
-    main_room_only=True,
+    parametrize_room=True,
 )
 async def addeightballanswer(msg: Message) -> None:
     if not msg.arg:
@@ -52,13 +59,17 @@ async def addeightballanswer(msg: Message) -> None:
 
     db = Database.open()
     with db.get_session() as session:
-        result = d.EightBall(answer=msg.arg)
+        result = d.EightBall(answer=msg.arg, roomid=msg.parametrized_room.roomid)
         session.add(result)
         session.commit()  # type: ignore  # sqlalchemy
 
         try:
             if result.id:
                 await msg.reply("Risposta salvata.")
+                if msg.room is None:
+                    await msg.parametrized_room.send_modnote(
+                        "EIGHTBALL ANSWER ADDED", msg.user, msg.arg
+                    )
                 return
         except ObjectDeletedError:
             pass
@@ -76,7 +87,7 @@ async def addeightballanswer(msg: Message) -> None:
         "rm8ballanswer",
     ),
     required_rank="driver",
-    main_room_only=True,
+    parametrize_room=True,
 )
 async def removeeightballanswer(msg: Message) -> None:
     if not msg.arg:
@@ -85,31 +96,162 @@ async def removeeightballanswer(msg: Message) -> None:
 
     db = Database.open()
     with db.get_session() as session:
-        result = session.query(d.EightBall).filter_by(answer=msg.arg).delete()
-
+        result = (
+            session.query(d.EightBall)
+            .filter_by(answer=msg.arg, roomid=msg.parametrized_room.roomid)
+            .delete()
+        )
         if result:
             await msg.reply("Risposta cancellata.")
+            if msg.room is None:
+                await msg.parametrized_room.send_modnote(
+                    "EIGHTBALL ANSWER REMOVED", msg.user, msg.arg
+                )
         else:
             await msg.reply("Risposta inesistente.")
 
 
-@command_wrapper(required_rank="driver", main_room_only=True)
+@command_wrapper(required_rank="driver", parametrize_room=True)
 async def removeeightballanswerid(msg: Message) -> None:
     if len(msg.args) != 2:
         return
 
     db = Database.open()
     with db.get_session() as session:
-        session.query(d.EightBall).filter_by(id=msg.args[0]).delete()
+        query = session.query(d.EightBall).filter_by(
+            id=msg.args[0], roomid=msg.parametrized_room.roomid
+        )
+        answer = query.first()
+        if answer:
+            if msg.room is None:
+                await msg.parametrized_room.send_modnote(
+                    "EIGHTBALL ANSWER REMOVED", msg.user, answer.answer
+                )
+            query.delete()
 
     try:
         page = int(msg.args[1])
     except ValueError:
         page = 1
 
-    await msg.user.send_htmlpage("eightball", msg.conn.main_room, page)
+    await msg.user.send_htmlpage("eightball", msg.parametrized_room, page)
 
 
-@htmlpage_wrapper("eightball", required_rank="driver", main_room_only=True)
+@htmlpage_wrapper("eightball", required_rank="driver")
 def eightball_htmlpage(user: User, room: Room) -> Query:  # type: ignore[type-arg]
-    return Query(d.EightBall).order_by(d.EightBall.answer)
+    return Query(d.EightBall).filter_by(roomid=room.roomid).order_by(d.EightBall.answer)
+
+
+DEFAULT_ANSWERS = {
+    "French": [
+        "Essaye plus tard",
+        "Essaye encore",
+        "Pas d'avis",
+        "C'est ton destin",
+        "Le sort en est jeté",
+        "Une chance sur deux",
+        "Repose ta question",
+        "D'après moi oui",
+        "C'est certain",
+        "Oui absolument",
+        "Tu peux compter dessus",
+        "Sans aucun doute",
+        "Très probable",
+        "Oui",
+        "C'est bien parti",
+        "C'est non",
+        "Peu probable",
+        "Faut pas rêver",
+        "N'y compte pas",
+        "Impossible",
+    ],
+    "German": [
+        "Zeichen deuten auf ja",
+        "Ja",
+        "Ohne einen Zweifel",
+        "Wie ich es sehe ja",
+        "Höchstwahrscheinlich",
+        "Darauf kannst du dich verlassen",
+        "Definitiv ja",
+        "Es ist so entschieden",
+        "Gute Aussichten",
+        "Es ist sicher",
+        "Antwort unklar, versuchs nochmal",
+        "Konzentriere dich und frag nochmal",
+        "Ich sags dir jetzt lieber nicht",
+        "Kann es jetzt nicht vorhersagen",
+        "Frag später nochmal",
+        "Meine Quellen sagen nein",
+        "Sehr zweifelhaft",
+        "Zähl nicht drauf",
+        "Nicht so gute Aussichten",
+        "Meine Antwort ist nein",
+    ],
+    "Spanish": [
+        "En mi opinión, sí",
+        "Es cierto",
+        "Es decididamente así",
+        "Probablemente",
+        "Buen pronóstico",
+        "Todo apunta a que sí",
+        "Sin duda",
+        "Sí",
+        "Sí - definitivamente",
+        "Debes confiar en ello",
+        "Respuesta vaga, vuelve a intentarlo",
+        "Pregunta en otro momento",
+        "Será mejor que no te lo diga ahora",
+        "No puedo predecirlo ahora",
+        "Concéntrate y vuelve a preguntar",
+        "Puede ser",
+        "No cuentes con ello",
+        "Mi respuesta es no",
+        "Mis fuentes me dicen que no",
+        "Las perspectivas no son buenas",
+        "Muy dudoso",
+    ],
+    "Italian": [
+        "Per quanto posso vedere, sì",
+        "È certo",
+        "È decisamente così",
+        "Molto probabilmente",
+        "Le prospettive sono buone",
+        "I segni indicano di sì",
+        "Senza alcun dubbio",
+        "Sì",
+        "Sì, senza dubbio",
+        "Ci puoi contare",
+        "È difficile rispondere, prova di nuovo",
+        "Rifai la domanda più tardi",
+        "Meglio non risponderti adesso",
+        "Non posso predirlo ora",
+        "Concentrati e rifai la domanda",
+        "Non ci contare",
+        "La mia risposta è no",
+        "Le mie fonti dicono di no",
+        "Le prospettive non sono buone",
+        "Molto incerto",
+    ],
+    "English": [
+        "It is certain",
+        "It is decidedly so",
+        "Without a doubt",
+        "Yes - definitely",
+        "You may rely on it",
+        "As I see it, yes",
+        "Most likely",
+        "Outlook good",
+        "Yes",
+        "Signs point to yes",
+        "Reply hazy, try again",
+        "Ask again later",
+        "Better not tell you now",
+        "Cannot predict now",
+        "Concentrate and ask again",
+        "Don't count on it",
+        "My reply is no",
+        "My sources say no",
+        "Outlook not so good",
+        "Very doubtful",
+    ],
+}

--- a/templates/htmlpages/eightball.html
+++ b/templates/htmlpages/eightball.html
@@ -15,7 +15,7 @@
           <tr>
             <td>{{ row.answer }}</td>
             <td style="width: 1px; white-space: nowrap">
-              {% set cmd = "removeeightballanswerid " + row.id|string + ", " + current_page|string %}
+              {% set cmd = "removeeightballanswerid " + room.roomid + ", " + row.id|string + ", " + current_page|string %}
               {% call utils.btn_sendpm(cmd) %}
                 <i class="fa fa-trash"></i>
                 Delete

--- a/tests/plugins/test_eightball.py
+++ b/tests/plugins/test_eightball.py
@@ -1,0 +1,82 @@
+import plugins.eightball
+
+
+def test_eightball(mock_connection):
+    conn, recv_queue, send_queue = mock_connection()
+
+    recv_queue.add_user_join("room1", "user1", "+")
+    recv_queue.add_user_join("room1", "mod", "@")
+    recv_queue.add_user_join("room1", "cerbottana", "*")
+    send_queue.get_all()
+
+    recv_queue.add_messages(
+        [
+            f"|pm| user1| {conn.username}|.8ball",
+        ]
+    )
+    reply = send_queue.get_all()
+    assert len(reply) == 1
+    assert (
+        next(iter(reply)).replace("|/w user1, ", "")
+        in plugins.eightball.DEFAULT_ANSWERS["English"]
+    )
+
+    for lang in plugins.eightball.DEFAULT_ANSWERS:
+        recv_queue.add_messages(
+            [
+                ">room1",
+                f"This room's primary language is {lang}",
+            ]
+        )
+        recv_queue.add_messages(
+            [
+                ">room1",
+                "|c|+user1|.8ball",
+            ]
+        )
+        reply = send_queue.get_all()
+        assert len(reply) == 1
+        assert (
+            next(iter(reply)).replace("room1|", "")
+            in plugins.eightball.DEFAULT_ANSWERS[lang]
+        )
+
+    recv_queue.add_messages(
+        [
+            ">room1",
+            "This room's primary language is Japanese",
+        ]
+    )
+    recv_queue.add_messages(
+        [
+            ">room1",
+            "|c|+user1|.8ball",
+        ]
+    )
+    reply = send_queue.get_all()
+    assert len(reply) == 1
+    assert (
+        next(iter(reply)).replace("room1|", "")
+        in plugins.eightball.DEFAULT_ANSWERS["English"]
+    )
+
+    plugins.eightball.DEFAULT_ANSWERS = {"English": []}
+
+    recv_queue.add_messages(
+        [
+            ">room1",
+            "|c|@mod|.add8ballanswer answ",
+        ]
+    )
+    send_queue.get_all()
+    recv_queue.add_messages(
+        [
+            ">room1",
+            "|c|+user1|.8ball",
+        ]
+    )
+    reply = send_queue.get_all()
+    assert len(reply) == 1
+    assert next(iter(reply)).replace("room1|", "") == "answ"
+
+    recv_queue.close()


### PR DESCRIPTION
Default answers are now hardcoded in the `.eightball` command, and are also available in french, spanish and italian. I was going to add german as well, but the [german wikipedia page](https://de.wikipedia.org/wiki/Magic_8_Ball#M%C3%B6gliche_Antworten) only shows the english versions.

When this goes in production I'll have to remove the default answers from the database. I'm not doing this in the alembic migration script because they never were into this repository

Closes #167 