### PR TITLE
Show !tier info at the start of non-random tours 

### DIFF
--- a/handlers/formats.py
+++ b/handlers/formats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from handlers import handler_wrapper
@@ -32,6 +33,7 @@ async def formats(conn: Connection, room: Room, *args: str) -> None:
         if section is not None:
             tiers.append(
                 {
+                    "id": re.sub(r"[^a-z0-9]", "", parts[0].lower()),
                     "name": parts[0],
                     "section": section,
                     "random": bool(int(parts[1], 16) & 1),

--- a/typedefs.py
+++ b/typedefs.py
@@ -10,6 +10,7 @@ JsonDict = Dict[str, Any]  # type: ignore[misc]
 
 
 class TiersDict(TypedDict):
+    id: str
     name: str
     section: str
     random: bool


### PR DESCRIPTION
Closes #202.

Not sure if you wanted this to be in a separate plugin file or if it's fine to have it in `tours.py`. Let me know!
I added an `id` parameter to `TiersDict`. It's simpler and faster to compute it only once when we populate the `conn.tiers` list.
All of the non-random non-custom formats work with `!tier` and at least show the Banlist/Ruleset section.