### PR TITLE
Update sprites logic to use PS data

### DIFF
--- a/handlers/formats.py
+++ b/handlers/formats.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
+import utils
 from handlers import handler_wrapper
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ async def formats(conn: Connection, room: Room, *args: str) -> None:
         if section is not None:
             tiers.append(
                 {
-                    "id": re.sub(r"[^a-z0-9]", "", parts[0].lower()),
+                    "id": utils.to_id(parts[0]),
                     "name": parts[0],
                     "section": section,
                     "random": bool(int(parts[1], 16) & 1),

--- a/tests/plugins/test_sprites.py
+++ b/tests/plugins/test_sprites.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import plugins.sprites as sprites
+import utils
 
 
 @pytest.mark.parametrize(
@@ -16,6 +17,9 @@ import plugins.sprites as sprites
     ),
 )
 def test_generate_sprite_url(pokemon: str, dexname: str) -> None:
-    """Tests PS sprite URLs are generated correctly from pokemon names."""
+    """Tests that PS sprite URLs are generated correctly from pokemon names."""
+    dex_entry = utils.get_ps_dex_entry(pokemon)
+    assert dex_entry is not None
+
     expected_url = f"https://play.pokemonshowdown.com/sprites/ani/{dexname}.gif"
-    assert sprites.generate_sprite_url(pokemon, False) == expected_url
+    assert sprites.generate_sprite_url(dex_entry, False) == expected_url

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,7 @@ from sqlalchemy.sql import func
 
 import databases.database as d
 from database import Database
-from typedefs import Role, RoomId, UserId
+from typedefs import JsonDict, Role, RoomId, UserId
 
 
 def create_token(
@@ -226,5 +226,33 @@ def get_language_id(language_name: str) -> int:
     return table["English"]  # Default to English if language is not available.
 
 
+def get_ps_dex_entry(query: str) -> JsonDict | None:
+    """Retrieves a pokemon entry from the PS pokedex.
+
+    Args:
+        query (str): Pokemon name (or forme variant).
+
+    Returns:
+        JsonDict | None: Dict with pokemon information or None if no pokemon was
+            recognized.
+    """
+    query = _escape(query)
+    if query in ALIASES:
+        query = _escape(ALIASES[query])
+    if query in POKEDEX:
+        return POKEDEX[query]
+    return None
+
+
+def _escape(text: str) -> str:
+    text = remove_accents(text)
+    text = to_id(text)
+    return text
+
+
 with open("./data/avatars.json") as f:
     AVATAR_IDS: dict[str, str] = json.load(f)
+with open("./data/showdown/aliases.json") as f:
+    ALIASES: dict[str, str] = json.load(f)
+with open("./data/showdown/pokedex.json") as f:
+    POKEDEX: dict[str, JsonDict] = json.load(f)

--- a/utils.py
+++ b/utils.py
@@ -51,8 +51,12 @@ def create_token(
     return token_id
 
 
+def to_id(text: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
 def to_user_id(user: str) -> UserId:
-    userid = UserId(re.sub(r"[^a-z0-9]", "", user.lower()))
+    userid = UserId(to_id(user))
     return userid
 
 


### PR DESCRIPTION
Closes #201.

I added a generic `to_id` utility function as discussed privately. In the future we could consider having `remove_accents` as a parameter but it's outside the scope of this PR, I'll think about it.

I created an utility function to query the `pokedex.json` data and added it to `utils.py`. I think the module is getting quite messy though, and I'll try to modularize it.

For the `.randsprite` logic we still rely on Veekun to get a random pokemon and _then_ retrieve its PS data. Trying to get a random entry from `pokedex.json` directly also includes CAPmons (which I'd prefer to exclude) and some probably unwanted forme variants that could also lack a sprite (e.g. totem forms).
