### PR TITLE
Change format of monopoke/randpoke to ou

### DIFF
--- a/cerbottana/plugins/tours.py
+++ b/cerbottana/plugins/tours.py
@@ -117,7 +117,7 @@ async def monopoketour(msg: Message) -> None:
 
     await create_tour(
         msg,
-        formatid="nationaldex",
+        formatid="ou",
         name="MONOPOKE TOUR",
         autostart=6.5,
         rules=["-All Pokemon", f"+{msg.arg}-base", "-Focus Sash", "Z-Move Clause"],
@@ -135,7 +135,7 @@ async def randpoketour(msg: Message) -> None:
         await msg.reply("Inserisci almeno un Pokémon")
         return
 
-    formatid = "nationaldex"
+    formatid = "ou"
     name = "!RANDPOKE TOUR"
     rules = ["Z-Move Clause", "Dynamax Clause"]
     bans = ["All Pokemon"]


### PR DESCRIPTION
The NatDex OU rule that unbans Pokémon illegal in Gen 8 overrides the -AllPokemon custom rule. However, Pokémon that are illegal in Gen 8 OU can still be unbanned with the +Pokemon custom rule.

[Reference 1](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-59#post-8921577), [reference 2](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-69#post-9066792)